### PR TITLE
chore: rename payload size to item size to align with other tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To generate `snapshot.jsonl` from `snapshot.rdb`, run the script with `rdb-to-js
 
 i. The validate tool identifies potential incompatibilities with Momento. When running the first time, we should explore all potential incompatiblities. To do this, enable all the flags:
 
-`./MomentoEtl validate --maxTtl <MAX-TTL-IN-DAYS> --maxPayloadSize <MAX-SIZE-IN-MiB-OF-ITEM> --filterLongTtl --filterAlreadyExpired --filterMissingTtl <DATA-PATH> <VALID-PATH> <ERROR-PATH>`
+`./MomentoEtl validate --maxTtl <MAX-TTL-IN-DAYS> --maxItemSize <MAX-SIZE-IN-MiB-OF-ITEM> --filterLongTtl --filterAlreadyExpired --filterMissingTtl <DATA-PATH> <VALID-PATH> <ERROR-PATH>`
 
 For example:
 
@@ -74,7 +74,7 @@ Which reads from `snapshot.jsonl`, writes data that passes the filters to `valid
 
 ii. After doing an initial analysis, run the tool with a relaxed set of filters. Because a TTL that is too long can be clipped, a missing one can have one applied, etc. we can still store these items. Because an item that is too large is not recoverable and neither is an unsupported data type, we still filter those:
 
-`./MomentoEtl validate --maxPayloadSize 1 snapshot.jsonl valid.jsonl error.jsonl`
+`./MomentoEtl validate --maxItemSize 1 snapshot.jsonl valid.jsonl error.jsonl`
 
 ## Load the data into Momento
 

--- a/scripts/extract-and-validate.sh
+++ b/scripts/extract-and-validate.sh
@@ -5,8 +5,8 @@ set -x
 # This directory structure is necessary for the docker container
 data_path=$1
 
-# Max payload size in MiB
-max_payload_size=$2
+# Max item size in MiB
+max_item_size=$2
 
 # Max TTL in days
 max_ttl=$3
@@ -55,7 +55,7 @@ function is_set_or_panic() {
 
 dir_exists_or_panic $data_path
 file_exists_or_panic $momento_etl_path
-is_set_or_panic "$max_payload_size" "max_payload_size"
+is_set_or_panic "$max_item_size" "max_item_size"
 is_set_or_panic "$max_ttl" "max_ttl"
 
 stage1_path=$data_path/stage1
@@ -123,7 +123,7 @@ done
 
 # STRICT
 $momento_etl_path validate \
-    --maxPayloadSize $max_payload_size \
+    --maxItemSize $max_item_size \
     --maxTtl $max_ttl --filterLongTtl \
     --filterAlreadyExpired \
     --filterMissingTtl \
@@ -138,7 +138,7 @@ fi
 
 # LAX
 $momento_etl_path validate \
-    --maxPayloadSize $max_payload_size \
+    --maxItemSize $max_item_size \
     $joined_file $stage3_lax_path/valid $stage3_lax_path/error \
     2>&1 | tee $stage3_lax_path/log
 

--- a/src/Momento.Etl/Cli/Validate/Command.cs
+++ b/src/Momento.Etl/Cli/Validate/Command.cs
@@ -22,8 +22,8 @@ public class Command
         var dataValidators = new DataValidatorChain();
         if (options.FilterLargeData)
         {
-            logger.LogInformation($"Filtering payloads larger than {options.MaxPayloadSize}MiB");
-            dataValidators.AddDataValidator(new PayloadSizeValidator(options.MaxPayloadSize));
+            logger.LogInformation($"Filtering items larger than {options.MaxItemSize}MiB");
+            dataValidators.AddDataValidator(new ItemSizeValidator(options.MaxItemSize));
         }
         if (options.FilterLongTtl)
         {

--- a/src/Momento.Etl/Cli/Validate/Options.cs
+++ b/src/Momento.Etl/Cli/Validate/Options.cs
@@ -6,8 +6,8 @@ namespace Momento.Etl.Cli.Validate;
 [Verb("validate", HelpText = "validate redis data for momento")]
 public class Options
 {
-    [Option("maxPayloadSize", Required = false, HelpText = "Max payload size in MiB, inclusive. Defaults to 1.")]
-    public int MaxPayloadSize { get; set; } = 1;
+    [Option("maxItemSize", Required = false, HelpText = "Max item size in MiB, inclusive. Defaults to 1.")]
+    public int MaxItemSize { get; set; } = 1;
 
     [Option("filterLargeData", Required = false, HelpText = "Test for payloads that exceed the max. Defaults to true.")]
     public bool FilterLargeData { get; set; } = true;
@@ -36,7 +36,7 @@ public class Options
     public void Validate()
     {
         OptionUtils.TryOpenFile(DataFilePath);
-        OptionUtils.AssertStrictlyPositive(MaxPayloadSize, "maxPayloadSize");
+        OptionUtils.AssertStrictlyPositive(MaxItemSize, "maxItemSize");
         OptionUtils.AssertStrictlyPositive(MaxTtl, "maxTtl");
     }
 }

--- a/src/Momento.Etl/Model/Extensions.cs
+++ b/src/Momento.Etl/Model/Extensions.cs
@@ -12,7 +12,7 @@ public static class Extensions
     /// </summary>
     /// <param name="s"></param>
     /// <returns></returns>
-    public static int PayloadSizeInBytes(this string s)
+    public static int ItemSizeInBytes(this string s)
     {
         if (s is null)
         {

--- a/src/Momento.Etl/Model/RedisHash.cs
+++ b/src/Momento.Etl/Model/RedisHash.cs
@@ -14,9 +14,9 @@ public record RedisHash : RedisItem
         this.Expiry = expiry;
     }
 
-    public override int PayloadSizeInBytes()
+    public override int ItemSizeInBytes()
     {
-        return base.PayloadSizeInBytes() + Value.Sum(item => item.Key.PayloadSizeInBytes() + item.Value.PayloadSizeInBytes());
+        return base.ItemSizeInBytes() + Value.Sum(item => item.Key.ItemSizeInBytes() + item.Value.ItemSizeInBytes());
     }
 
     public override string ToString()

--- a/src/Momento.Etl/Model/RedisItem.cs
+++ b/src/Momento.Etl/Model/RedisItem.cs
@@ -38,10 +38,10 @@ public abstract record RedisItem
     /// Used to validate if an item is too large for the cache.
     /// </summary>
     /// <returns></returns>
-    public virtual int PayloadSizeInBytes()
+    public virtual int ItemSizeInBytes()
     {
         // We always include the expiry because Momento requires one, even though Redis does not.
         var sizeOfExpiry = sizeof(long);
-        return Key.PayloadSizeInBytes() + sizeOfExpiry;
+        return Key.ItemSizeInBytes() + sizeOfExpiry;
     }
 }

--- a/src/Momento.Etl/Model/RedisList.cs
+++ b/src/Momento.Etl/Model/RedisList.cs
@@ -12,9 +12,9 @@ public record RedisList : RedisItem
         this.Expiry = expiry;
     }
 
-    public override int PayloadSizeInBytes()
+    public override int ItemSizeInBytes()
     {
-        return base.PayloadSizeInBytes() + Value.Sum(item => item.PayloadSizeInBytes());
+        return base.ItemSizeInBytes() + Value.Sum(item => item.ItemSizeInBytes());
     }
 
     public override string ToString()

--- a/src/Momento.Etl/Model/RedisSet.cs
+++ b/src/Momento.Etl/Model/RedisSet.cs
@@ -10,9 +10,9 @@ public record RedisSet : RedisItem
         this.Expiry = expiry;
     }
 
-    public override int PayloadSizeInBytes()
+    public override int ItemSizeInBytes()
     {
-        return base.PayloadSizeInBytes() + Value.Sum(item => item.PayloadSizeInBytes());
+        return base.ItemSizeInBytes() + Value.Sum(item => item.ItemSizeInBytes());
     }
 
     public override string ToString()

--- a/src/Momento.Etl/Model/RedisString.cs
+++ b/src/Momento.Etl/Model/RedisString.cs
@@ -10,9 +10,9 @@ public record RedisString : RedisItem
         this.Expiry = expiry;
     }
 
-    public override int PayloadSizeInBytes()
+    public override int ItemSizeInBytes()
     {
-        return base.PayloadSizeInBytes() + Value.PayloadSizeInBytes();
+        return base.ItemSizeInBytes() + Value.ItemSizeInBytes();
     }
 
     public override string ToString()

--- a/src/Momento.Etl/Validation/ItemSizeValidator.cs
+++ b/src/Momento.Etl/Validation/ItemSizeValidator.cs
@@ -5,18 +5,18 @@ namespace Momento.Etl.Validation;
 /// <summary>
 /// Tests whether an item size is within the max limit.
 /// </summary>
-public class PayloadSizeValidator : IDataValidator
+public class ItemSizeValidator : IDataValidator
 {
     private readonly int maxSizeInBytes;
 
-    public PayloadSizeValidator(int maxSizeInMiB)
+    public ItemSizeValidator(int maxSizeInMiB)
     {
         maxSizeInBytes = maxSizeInMiB * 1024 * 1024;
     }
 
     public ValidationResult Validate(RedisItem item)
     {
-        if (item.PayloadSizeInBytes() <= maxSizeInBytes)
+        if (item.ItemSizeInBytes() <= maxSizeInBytes)
         {
             return ValidationResult.OK.Instance;
         }

--- a/tests/Momento.Etl/Model.Tests/RedisHashTest.cs
+++ b/tests/Momento.Etl/Model.Tests/RedisHashTest.cs
@@ -11,6 +11,6 @@ public class RedisHashTest
     public void PayloadSizeInBytes_HasExpiry_HappyPath()
     {
         var item = new RedisHash("key", new Dictionary<string, string>() { { "hello", "hola" }, { "goodbye", "adios" } }, 123);
-        Assert.Equal(32, item.PayloadSizeInBytes());
+        Assert.Equal(32, item.ItemSizeInBytes());
     }
 }

--- a/tests/Momento.Etl/Model.Tests/RedisListTest.cs
+++ b/tests/Momento.Etl/Model.Tests/RedisListTest.cs
@@ -11,6 +11,6 @@ public class RedisListTest
     public void PayloadSizeInBytes_HasExpiry_HappyPath()
     {
         var item = new RedisList("key", new List<string>() { "hello", "hola" }, 123);
-        Assert.Equal(20, item.PayloadSizeInBytes());
+        Assert.Equal(20, item.ItemSizeInBytes());
     }
 }

--- a/tests/Momento.Etl/Model.Tests/RedisSet.cs
+++ b/tests/Momento.Etl/Model.Tests/RedisSet.cs
@@ -11,6 +11,6 @@ public class RedisSetTest
     public void PayloadSizeInBytes_HasExpiry_HappyPath()
     {
         var item = new RedisSet("key", new List<string>() { "hello", "hola" }, 123);
-        Assert.Equal(20, item.PayloadSizeInBytes());
+        Assert.Equal(20, item.ItemSizeInBytes());
     }
 }

--- a/tests/Momento.Etl/Model.Tests/RedisStringTest.cs
+++ b/tests/Momento.Etl/Model.Tests/RedisStringTest.cs
@@ -10,6 +10,6 @@ public class RedisStringTest
     public void PayloadSizeInBytes_HasExpiry_HappyPath()
     {
         var item = new RedisString("key", "value", 123);
-        Assert.Equal(16, item.PayloadSizeInBytes());
+        Assert.Equal(16, item.ItemSizeInBytes());
     }
 }

--- a/tests/Momento.Etl/Validation.Tests/DataValidatorChainTest.cs
+++ b/tests/Momento.Etl/Validation.Tests/DataValidatorChainTest.cs
@@ -21,7 +21,7 @@ public class DataValidatorChainTest
     public void Validate_ThreeValidators_HappyPath()
     {
         var validators = new List<IDataValidator>()
-            { new HasTtlValidator(), new TtlInRangeValidator(TimeSpan.FromHours(1)), new PayloadSizeValidator(1) };
+            { new HasTtlValidator(), new TtlInRangeValidator(TimeSpan.FromHours(1)), new ItemSizeValidator(1) };
         var chain = new DataValidatorChain(validators);
 
         var result = chain.Validate(new RedisString("hello", "world", DateTime.Now.ToUnixTimeMilliseconds()));

--- a/tests/Momento.Etl/Validation.Tests/ItemSizeValidatorTest.cs
+++ b/tests/Momento.Etl/Validation.Tests/ItemSizeValidatorTest.cs
@@ -5,12 +5,12 @@ using Xunit;
 
 namespace Momento.Etl.Validation.Tests;
 
-public class PayloadSizeValidatorTest
+public class ItemSizeValidatorTest
 {
     [Fact]
     public void Validate_InLimits_OK()
     {
-        var validator = new PayloadSizeValidator(1);
+        var validator = new ItemSizeValidator(1);
         var result = validator.Validate(new RedisString("hello", "world", 123));
         Assert.True(result is ValidationResult.OK, $"result was not OK, instead was {result.GetType().Name}");
     }
@@ -23,10 +23,10 @@ public class PayloadSizeValidatorTest
         // Since the expiry is 8 bytes, we make the key and value large enough for it all to equal 1 MiB
         var largeString = Utils.RepeatChar('a', (1024 * 1024) / 2 - 4);
         var item = new RedisString(largeString, largeString);
-        Assert.Equal(1024 * 1024, item.PayloadSizeInBytes());
+        Assert.Equal(1024 * 1024, item.ItemSizeInBytes());
 
         // Test max size inclusive
-        var validator = new PayloadSizeValidator(1);
+        var validator = new ItemSizeValidator(1);
         var result = validator.Validate(item);
         Assert.True(result is ValidationResult.OK);
     }
@@ -39,10 +39,10 @@ public class PayloadSizeValidatorTest
         var largeString1 = Utils.RepeatChar('a', (1024 * 1024) / 2 - 4);
         var largeString2 = largeString1 + 'a';
         var item = new RedisString(largeString1, largeString2);
-        Assert.Equal(1024 * 1024 + 1, item.PayloadSizeInBytes());
+        Assert.Equal(1024 * 1024 + 1, item.ItemSizeInBytes());
 
         // Test max size inclusive
-        var validator = new PayloadSizeValidator(1);
+        var validator = new ItemSizeValidator(1);
         var result = validator.Validate(item);
         Assert.True(result is ValidationResult.Error, $"result wasn't Error, instead was {result.GetType().Name}");
         ValidationResult.Error error = (ValidationResult.Error)result;


### PR DESCRIPTION
Other internal tools use the nomenclature "item size" as opposed to
"payload size". This PR refactors the name.

Addresses #13 
