### PR TITLE
chore: bump `Momento.Sdk` to latest version

### DIFF
--- a/src/Momento.Etl/Cli/Cli.csproj
+++ b/src/Momento.Etl/Cli/Cli.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Momento.Sdk.Incubating" Version="0.9.0-alpha" />
+    <PackageReference Include="Momento.Sdk" Version="1.12.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 

--- a/src/Momento.Etl/Cli/Load/Command.cs
+++ b/src/Momento.Etl/Cli/Load/Command.cs
@@ -1,8 +1,7 @@
 using Microsoft.Extensions.Logging;
 using Momento.Etl.Model;
-using Momento.Sdk.Incubating;
-using Momento.Sdk.Incubating.Requests;
-using Momento.Sdk.Incubating.Responses;
+using Momento.Sdk;
+using Momento.Sdk.Requests;
 using Momento.Sdk.Responses;
 
 
@@ -11,10 +10,10 @@ namespace Momento.Etl.Cli.Load;
 public class Command : IDisposable
 {
     private ILogger logger;
-    private ISimpleCacheClient client;
+    private ICacheClient client;
     private bool createCache;
 
-    public Command(ILoggerFactory loggerFactory, ISimpleCacheClient client, bool createCache)
+    public Command(ILoggerFactory loggerFactory, ICacheClient client, bool createCache)
     {
         logger = loggerFactory.CreateLogger<Command>();
         this.client = client;

--- a/src/Momento.Etl/Cli/Program.cs
+++ b/src/Momento.Etl/Cli/Program.cs
@@ -4,9 +4,9 @@ using CommandLine;
 using CommandLine.Text;
 using Microsoft.Extensions.Logging;
 using Momento.Etl.Utils;
+using Momento.Sdk;
 using Momento.Sdk.Auth;
 using Momento.Sdk.Config;
-using Momento.Sdk.Incubating;
 
 namespace Momento.Etl.Cli;
 
@@ -84,7 +84,7 @@ public class Program
             // we opt to use a config we more relaxed timeouts.
             var config = Configurations.Laptop.Latest(loggerFactory);
             var authProvider = new StringMomentoTokenProvider(options.AuthToken);
-            var client = SimpleCacheClientFactory.CreateClient(config, authProvider, options.DefaultTtlTimeSpan);
+            var client = new CacheClient(config, authProvider, options.DefaultTtlTimeSpan);
 
             var command = new Load.Command(loggerFactory, client, options.CreateCache);
             await command.RunAsync(options.CacheName, options.FilePath, options.ResetAlreadyExpiredToDefaultTtl);
@@ -106,7 +106,7 @@ public class Program
             // we opt to use a config we more relaxed timeouts.
             var config = Configurations.Laptop.Latest(loggerFactory);
             var authProvider = new StringMomentoTokenProvider(options.AuthToken);
-            var client = SimpleCacheClientFactory.CreateClient(config, authProvider, TimeSpan.FromMinutes(1));
+            var client = new CacheClient(config, authProvider, TimeSpan.FromMinutes(1));
 
             var command = new Verify.Command(loggerFactory, client);
             await command.RunAsync(options.CacheName, options.FilePath);

--- a/src/Momento.Etl/Cli/Verify/Command.cs
+++ b/src/Momento.Etl/Cli/Verify/Command.cs
@@ -1,7 +1,6 @@
 using Microsoft.Extensions.Logging;
 using Momento.Etl.Model;
-using Momento.Sdk.Incubating;
-using Momento.Sdk.Incubating.Responses;
+using Momento.Sdk;
 using Momento.Sdk.Internal.ExtensionMethods;
 using Momento.Sdk.Responses;
 
@@ -11,9 +10,9 @@ namespace Momento.Etl.Cli.Verify;
 public class Command : IDisposable
 {
     private ILogger logger;
-    private ISimpleCacheClient client;
+    private ICacheClient client;
 
-    public Command(ILoggerFactory loggerFactory, ISimpleCacheClient client)
+    public Command(ILoggerFactory loggerFactory, ICacheClient client)
     {
         logger = loggerFactory.CreateLogger<Command>();
         this.client = client;


### PR DESCRIPTION
The previous version of the tool linked against
`Momento.Sdk.Incubating`. This pivots to `Momento.Sdk`, which is
otherwise the same modulo the client class name.
