### PR TITLE
chore: tweak README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ i. The validate tool identifies potential incompatibilities with Momento. When r
 
 For example:
 
-`./MomentoEtl validate --maxTtl 1 --maxPayloadSize 1 --filterLongTtl --filterAlreadyExpired --filterMissingTtl snapshot.jsonl valid.jsonl error.jsonl`
+`./MomentoEtl validate --maxTtl 1 --maxPayloadSize 1 --filterLongTtl --filterAlreadyExpired --filterMissingTtl snapshot.jsonl valid.jsonl error`
 
-Which reads from `snapshot.jsonl`, writes data that passes the filters to `valid.jsonl` and those that do not to `error.jsonl`. `error.jsonl` contains two columns separated by a tab. The first column contains an error message. This allows you to easily grep error types for analysis. Specifically an end user may wish to know which items have a longer TTL than allowed, which items are too big, and which data types are not supported.
+Which reads from `snapshot.jsonl`, writes data that passes the filters to `valid.jsonl` and those that do not to `error`. `error` contains two columns separated by a tab. The first column contains an error message. This allows you to easily grep error types for analysis. Specifically an end user may wish to know which items have a longer TTL than allowed, which items are too big, and which data types are not supported.
 
 ii. After doing an initial analysis, run the tool with a relaxed set of filters. Because a TTL that is too long can be clipped, a missing one can have one applied, etc. we can still store these items. Because an item that is too large is not recoverable and neither is an unsupported data type, we still filter those:
 
-`./MomentoEtl validate --maxItemSize 1 snapshot.jsonl valid.jsonl error.jsonl`
+`./MomentoEtl validate --maxItemSize 1 snapshot.jsonl valid.jsonl error`
 
 ## Load the data into Momento
 

--- a/scripts/extract-and-validate.sh
+++ b/scripts/extract-and-validate.sh
@@ -127,7 +127,7 @@ $momento_etl_path validate \
     --maxTtl $max_ttl --filterLongTtl \
     --filterAlreadyExpired \
     --filterMissingTtl \
-    $joined_file $stage3_strict_path/valid $stage3_strict_path/error \
+    $joined_file $stage3_strict_path/valid.jsonl $stage3_strict_path/error \
     2>&1 | tee $stage3_strict_path/log
 
 if [ $? -ne 0 ]
@@ -139,7 +139,7 @@ fi
 # LAX
 $momento_etl_path validate \
     --maxItemSize $max_item_size \
-    $joined_file $stage3_lax_path/valid $stage3_lax_path/error \
+    $joined_file $stage3_lax_path/valid.jsonl $stage3_lax_path/error \
     2>&1 | tee $stage3_lax_path/log
 
 if [ $? -ne 0 ]


### PR DESCRIPTION
Change the readme to using the `jsonl` prefix where appropriate, ie
for the valid file but not the error file.
