### PR TITLE
chore: separate dist artifacts by os

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,20 +26,14 @@ precommit: build format test
 .PHONY: publish
 ##  Build standalone executables
 publish:
-	@dotnet publish src/Momento.Etl/Cli -c Release -r linux-x64 -p:PublishSingleFile=true --self-contained false
-	@dotnet publish src/Momento.Etl/Cli -c Release -r osx-x64 -p:PublishSingleFile=true --self-contained false
-	@dotnet publish src/Momento.Etl/Cli -c Release -r win-x64 -p:PublishSingleFile=true --self-contained false
+	@dotnet publish src/Momento.Etl/Cli -c Release -r linux-x64 -p:PublishSingleFile=true --self-contained
+	@dotnet publish src/Momento.Etl/Cli -c Release -r osx-x64 -p:PublishSingleFile=true --self-contained
+	@dotnet publish src/Momento.Etl/Cli -c Release -r win-x64 -p:PublishSingleFile=true --self-contained
 
 .PHONY: dist
 ## Package up executables and scripts for deployment
 dist: clean publish
-	@mkdir -p dist/momento-etl/linux-x64 dist/momento-etl/osx-x64 dist/momento-etl/win-x64
-	@cp -r src/Momento.Etl/Cli/bin/Release/net6.0/linux-x64/publish/* dist/momento-etl/linux-x64
-	@cp -r src/Momento.Etl/Cli/bin/Release/net6.0/osx-x64/publish/* dist/momento-etl/osx-x64
-	@cp -r src/Momento.Etl/Cli/bin/Release/net6.0/win-x64/publish/* dist/momento-etl/win-x64
-	@cp scripts/extract-and-validate.sh dist/momento-etl
-	@cp scripts/load.sh dist/momento-etl
-	@cd dist && tar czvf momento-etl.tgz momento-etl/*
+	@./scripts/dist.sh
 
 # See <https://gist.github.com/klmr/575726c7e05d8780505a> for explanation.
 .PHONY: help

--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+for os_target in osx linux win; do
+  runtime="${os_target}-x64"
+  output_dir=momento-etl-$runtime
+  mkdir -p dist/$output_dir/bin
+  cp -r src/Momento.Etl/Cli/bin/Release/net6.0/$runtime/publish/* dist/$output_dir/bin
+  cp scripts/{extract-and-validate,load}.sh dist/$output_dir
+
+  if [ "$os_target" = "win" ]; then
+    sed -i "" "s/bin\/MomentoEtl/bin\/MomentoEtl.exe/g" dist/$output_dir/*.sh
+  fi
+
+  cd dist && tar czvf $output_dir.tgz $output_dir && cd ..
+done
+
+

--- a/scripts/extract-and-validate.sh
+++ b/scripts/extract-and-validate.sh
@@ -2,10 +2,9 @@
 #set -x
 
 function usage_exit() {
-    echo "Usage: $0 [-s size] [-t ttl] [-b path] <data_path>";
+    echo "Usage: $0 [-s size] [-t ttl] <data_path>";
     echo "  -s size     max item size, in MiB (default 1)";
     echo "  -t ttl      max ttl, in days (default 1)";
-    echo "  -b path     path to momento etl binary (default linux-x64/MomentoEtl)";
     echo "  <data_path> path to data directory (where redis/ is expected and stage1/ will be created)";
     exit 1;
 }
@@ -13,9 +12,9 @@ function usage_exit() {
 # Parse CLI args
 max_item_size=1
 max_ttl=1
-momento_etl_path="linux-x64/MomentoEtl"
+momento_etl_path="bin/MomentoEtl"
 
-while getopts "hs:t:b:" o; do
+while getopts "hs:t:" o; do
     case "$o" in
         h)
             usage_exit
@@ -25,9 +24,6 @@ while getopts "hs:t:b:" o; do
             ;;
         t)
             max_ttl=${OPTARG}
-            ;;
-        b)
-            momento_etl_path=${OPTARG}
             ;;
         *)
             usage_exit

--- a/scripts/load.sh
+++ b/scripts/load.sh
@@ -5,12 +5,11 @@
 #set -x
 
 function usage_exit() {
-    echo "Usage: $0 -a token -c cache [-t ttl] [-n N] [-b path] [-l path] [-r] data_path"
+    echo "Usage: $0 -a token -c cache [-t ttl] [-n N] [-l path] [-r] data_path"
     echo "  -a token    Momento auth token"
     echo "  -c cache    Momento cache name"
     echo "  -t ttl      default ttl for Momento cache, in days (defaults 1)"
     echo "  -n N        number of concurrent requests to make to Momento (defaults to 4)"
-    echo "  -b path     path to MomentoEtl binary (defaults to linux-x64/MomentoEtl))"
     echo "  -l path     path to write the log to (defaults to ./load.log)"
     echo "  -r          reset expired item ttl to default (defaults to false)"
     echo "  <data_path> path to data file to load"
@@ -19,11 +18,11 @@ function usage_exit() {
 
 default_ttl=1
 num_concurrent_requests=4
-momento_etl_path="linux-x64/MomentoEtl"
+momento_etl_path="bin/MomentoEtl"
 log_path="load.log"
 reset_expired_items=0
 
-while getopts "ha:c:t:n:b:l:r" o; do
+while getopts "ha:c:t:n:l:r" o; do
     case "$o" in
         h)
             usage_exit
@@ -39,9 +38,6 @@ while getopts "ha:c:t:n:b:l:r" o; do
             ;;
         n)
             num_concurrent_requests=${OPTARG}
-            ;;
-        b)
-            momento_etl_path=${OPTARG}
             ;;
         l)
             log_path=${OPTARG}


### PR DESCRIPTION
Makes the following changes:
- separates release tarballs by os (win, linux, osx)
- builds self-contained executables, ie packages the .NET runtime so a
user does not need to install that separately. The tarballs are ~30MB.
