### PR TITLE
feat: separate pipeline into separate E-T-L steps

### DIFF
--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -11,7 +11,7 @@ for os_target in osx linux win; do
   cp -r src/Momento.Etl/Cli/bin/Release/net6.0/$runtime/publish/* dist/$output_dir/bin
   mkdir -p dist/$output_dir/third-party
   cp -r dist/redis-rdb-cli dist/$output_dir/third-party
-  cp scripts/{extract-and-validate,load}.sh dist/$output_dir
+  cp scripts/{extract-rdb,validate,load}.sh dist/$output_dir
 
   if [ "$os_target" = "win" ]; then
     sed -i "" "s/bin\/MomentoEtl/bin\/MomentoEtl.exe/g" dist/$output_dir/*.sh

--- a/scripts/extract-rdb.sh
+++ b/scripts/extract-rdb.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+#set -x
+
+function usage_exit() {
+    echo "Usage: $0 <data_path> <output-path>";
+    echo "  <data_path>   path to a directory with rdb files";
+    echo "  <output-path> path to a directory where the output will be written";
+    exit 1;
+}
+
+# Parse CLI args
+rdb_cli_path="third-party/redis-rdb-cli/bin/rct"
+
+data_path=$1
+output_path=$2
+
+if [ -z "$data_path" ]; then
+  echo "Need to set data_path"
+  usage_exit
+fi
+
+if [ -z "$output_path" ]; then
+  echo "Need to set output_path"
+  usage_exit
+fi
+
+data_path=$(readlink -f $data_path)
+output_path=$(readlink -f $output_path)
+
+# Writes rdb -> jsonl at $data_path/stage1
+# - Joins to single jsonl file in $data_path/stage2
+
+function create_path_or_panic() {
+    mkdir -p $1
+    if [ $? -ne 0 ]
+    then
+        echo Could not create $1
+        exit 1
+    fi
+}
+
+function dir_exists_or_panic() {
+    if [ ! -d "$1" ]; then
+        echo "directory $1 does not exist but should; bailing."
+        exit 1
+    fi
+}
+
+function file_exists_or_panic() {
+    if [ ! -f "$1" ]; then
+        echo "file $1 does not exist but should; bailing."
+        exit 1
+    fi
+}
+
+dir_exists_or_panic $data_path
+dir_exists_or_panic $data_path
+file_exists_or_panic $rdb_cli_path
+
+echo "=== EXTRACT RDB WITH THE FOLLOWING SETTINGS ==="
+echo "data_path = ${data_path}"
+
+stage1_path=$output_path/stage1
+
+create_path_or_panic $stage1_path
+
+# Flush any data from previous runs
+rm -f $stage1_path/*
+
+###############
+# STAGE 1: RDB -> JSONL
+###############
+
+echo
+echo ==== STAGE 1: EXTRACT RDB TO JSONL
+
+# Because the rct tool assumes it is run from the bin directory
+# we need to change to that directory before running it
+pushd "$(dirname $rdb_cli_path)" > /dev/null
+rdb_cli_filename="$(basename $rdb_cli_path)"
+
+for file in `ls $data_path/*rdb`
+do
+    rdb_filename="$(basename $file)"
+    jsonl_filename="${rdb_filename%.*}.jsonl"
+
+    # Get the directory that the rdb file is in
+    # This is necessary because rdb-cli will create a file in the current directory
+    # and we want to put it in the stage1 directory
+    ./${rdb_cli_filename} -f jsonl -s $file -o $stage1_path/$jsonl_filename
+
+    if [ $? -ne 0 ]; then
+        echo "Error converting RDB to JSONL, bailing: $?"
+        exit 1
+    fi
+done
+popd > /dev/null
+
+echo Finished extract extract-rdb. Inspect the data at $stage1_path

--- a/scripts/load.sh
+++ b/scripts/load.sh
@@ -5,13 +5,13 @@
 #set -x
 
 function usage_exit() {
-    echo "Usage: $0 -a token -c cache [-t ttl] [-n N] [-l path] [-r] data_path"
+    echo "Usage: $0 -a token -c cache [-t ttl] [-n N] [-r] [-l path] data_path"
     echo "  -a token    Momento auth token"
     echo "  -c cache    Momento cache name"
     echo "  -t ttl      default ttl for Momento cache, in days (defaults 1)"
     echo "  -n N        number of concurrent requests to make to Momento (defaults to 4)"
-    echo "  -l path     path to write the log to (defaults to ./load.log)"
     echo "  -r          reset expired item ttl to default (defaults to false)"
+    echo "  -l path     path to write the log to (defaults to ./load.log)"
     echo "  <data_path> path to data file to load"
     exit 1
 }
@@ -39,11 +39,11 @@ while getopts "ha:c:t:n:l:r" o; do
         n)
             num_concurrent_requests=${OPTARG}
             ;;
-        l)
-            log_path=${OPTARG}
-            ;;
         r)
             reset_expired_items=1
+            ;;
+        l)
+            log_path=${OPTARG}
             ;;
         *)
             usage_exit
@@ -93,13 +93,15 @@ else
     reset_expired_items=""
 fi
 
+echo
+
 $momento_etl_path load \
   -a $auth_token \
 	-c $cache_name \
 	--defaultTtl $default_ttl \
   -n $num_concurrent_requests \
   $reset_expired_items \
-	$data_path 2>&1 > $log_path
+	$data_path 2>&1 | tee $log_path
 
 if [ $? -ne 0 ]
 then


### PR DESCRIPTION
Previously we had scripts for "extract-and-validate", and "load". This
coupled the validate portion to extracting from RDB. In this PR we
separate out the extract step into a separate script. That way in the
README/examples we demonstrate extracting from any format {rdb, csv,
...} first, then the same validate and load steps after.
