### PR TITLE
chore: finalize scripts

### DIFF
--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -11,7 +11,7 @@ for os_target in osx linux win; do
   cp -r src/Momento.Etl/Cli/bin/Release/net6.0/$runtime/publish/* dist/$output_dir/bin
   mkdir -p dist/$output_dir/third-party
   cp -r dist/redis-rdb-cli dist/$output_dir/third-party
-  cp scripts/{extract-rdb,validate,load}.sh dist/$output_dir
+  cp scripts/{extract-rdb,extract-rdb-and-validate,validate,load}.sh dist/$output_dir
 
   if [ "$os_target" = "win" ]; then
     sed -i "" "s/bin\/MomentoEtl/bin\/MomentoEtl.exe/g" dist/$output_dir/*.sh

--- a/scripts/extract-rdb-and-validate.sh
+++ b/scripts/extract-rdb-and-validate.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+#set -x
+
+function usage_exit() {
+    echo "Usage: $0 [-s size] [-t ttl] <data_path> <output-path>";
+    echo "  -s size       max item size, in MiB (default 1)";
+    echo "  -t ttl        max ttl, in days (default 1)";
+    echo "  <data_path>   path to directory with jsonl files to validate";
+    echo "  <output-path> path to a directory where the output will be written";
+    echo
+    echo "Description: pipelines extract-rdb and validate.";
+    echo "  See the individual script usage descriptions for more details.";
+    exit 1;
+}
+
+# Parse CLI args
+max_item_size=1
+max_ttl=1
+
+while getopts "hs:t:" o; do
+    case "$o" in
+        h)
+            usage_exit
+            ;;
+        s)
+            max_item_size=${OPTARG}
+            ;;
+        t)
+            max_ttl=${OPTARG}
+            ;;
+        *)
+            usage_exit
+            ;;
+    esac
+done
+shift $(($OPTIND-1))
+
+data_path=$1
+output_path=$2
+
+if [ -z "$data_path" ]; then
+  echo "Need to set data_path"
+  usage_exit
+fi
+
+if [ -z "$output_path" ]; then
+  echo "Need to set output_path"
+  usage_exit
+fi
+
+extract_path=$output_path/extract
+./extract-rdb.sh $data_path $extract_path
+./validate.sh -s $max_item_size -t $max_ttl $extract_path $output_path

--- a/scripts/load.sh
+++ b/scripts/load.sh
@@ -13,6 +13,13 @@ function usage_exit() {
     echo "  -r          reset expired item ttl to default (defaults to false)"
     echo "  -l path     path to write the log to (defaults to ./load.log)"
     echo "  <data_path> path to data file to load"
+    echo
+    echo "Description: Loads a single data file into Momento."
+    echo "  Data file is assumed to be jsonl file located at: <data_path>."
+    echo "  The data will be stored in the cache named <cache> using the auth token <token>."
+    echo "  Data lacking an expiry will be given a default expiry of <ttl> days."
+    echo "  For data with an expiry, TTL is calculated from the timestamp in the data file relative to now."
+    echo "  Data already expired will be discarded, unless -r is specified."
     exit 1
 }
 

--- a/src/Momento.Etl/Cli/Load/Command.cs
+++ b/src/Momento.Etl/Cli/Load/Command.cs
@@ -166,10 +166,12 @@ public class Command : IDisposable
         else if (deleteResponse is CacheDeleteResponse.Error error)
         {
             logger.LogError($"error_deleting: {error.Message}; {line}");
+            return;
         }
         else
         {
             logger.LogError($"unknown_response: {line}");
+            return;
         }
 
         var concatenateResponse = await client.ListConcatenateFrontAsync(cacheName, item.Key, item.Value, null, new CollectionTtl(ttl, true));


### PR DESCRIPTION
Modifies the scripts output and input directories per discussions.

Adds rich descriptions to usage statements.

Fixes bug in loader: if a list fails to delete, we should not store
the incoming list because list concatenate is non-idempotent.
