### PR TITLE
fix: version bump fix

### DIFF
--- a/.github/workflows/on-push-to-release-branch.yml
+++ b/.github/workflows/on-push-to-release-branch.yml
@@ -60,7 +60,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           allow-initial-development-versions: true
           force-bump-patch-version: true
-          dry: false
+          #dry: true
           # For whatever reason, this silly tool won't let you do releases from branches
           #  other than the default branch unless you pass this flag, which doesn't seem
           #  to actually have anything to do with CI:


### PR DESCRIPTION
The version bump fails with ENOENT: no such file or directory, open
'.version-unreleased'. Unclear if this is due to the dry version
flag.
