### PR TITLE
fix: release assets

### DIFF
--- a/.github/workflows/on-push-to-release-branch.yml
+++ b/.github/workflows/on-push-to-release-branch.yml
@@ -84,7 +84,6 @@ jobs:
 
       - name: Upload release artifacts to release page
         run: |
-          pip install git-archive-all
           AUTH="Authorization: token ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}"
           VERSION=${{ needs.release.outputs.version }}
           cd dist
@@ -93,11 +92,6 @@ jobs:
           do
             cp momento-bulk-writer-$runtime.tgz momento-bulk-writer-$runtime-$VERSION.tgz
             ARCHIVE_FILE=momento-bulk-writer-$runtime-$VERSION.tgz
-            echo "ARCHIVE_FILE="$ARCHIVE_FILE >> $GITHUB_ENV
-            git-archive-all $ARCHIVE_FILE
-            SHA=$(openssl sha256 < ${ARCHIVE_FILE} | sed 's/.* //')
-            echo "SHA="$SHA >> $GITHUB_ENV
-            echo "sha is: ${SHA}"
             LATEST_RELEASE=$(curl -sH "$AUTH" https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/v${VERSION})
             RELEASE_ID=$(echo $LATEST_RELEASE | jq -r .id)
             GH_ASSET="https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets?name=${ARCHIVE_FILE}"


### PR DESCRIPTION
The previous version mixed the source release with the packaged
distributable. This fixes the `publish` step to just publish the
packaged distributable.
