### PR TITLE
chore: retire the machine-user release token

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -9,6 +9,13 @@ jobs:
   merge-to-release-branch:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate release bot token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.MOMENTO_RELEASE_APP_ID }}
+          private-key: ${{ secrets.MOMENTO_RELEASE_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@main
 
       - name: Merge main -> release
@@ -17,4 +24,4 @@ jobs:
           type: now
           from_branch: main
           target_branch: release
-          github_token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/on-push-to-release-branch.yml
+++ b/.github/workflows/on-push-to-release-branch.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   release:
     permissions:
+      # An explicit block zeroes every unlisted scope, and this job also needs
+      # contents for checkout and for go-semantic-release to cut the tag/release.
+      contents: write
       issues: write
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/on-push-to-release-branch.yml
+++ b/.github/workflows/on-push-to-release-branch.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   release:
+    permissions:
+      issues: write
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.semrel.outputs.version }}
@@ -43,7 +45,7 @@ jobs:
       - uses: trstringer/manual-approval@v1
         if: ${{ steps.major-version-bump-match.outputs.matched == 'true' }}
         with:
-          secret: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
+          secret: ${{ secrets.GITHUB_TOKEN }}
           # TODO: replace with public team
           approvers: malandis,cprice404,eaddingtonwhite
           minimum-approvals: 1
@@ -69,6 +71,8 @@ jobs:
           custom-arguments: "--no-ci"
 
   publish:
+    permissions:
+      contents: write
     needs: release
     runs-on: ubuntu-latest
     steps:
@@ -84,7 +88,7 @@ jobs:
 
       - name: Upload release artifacts to release page
         run: |
-          AUTH="Authorization: token ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}"
+          AUTH="Authorization: token ${{ secrets.GITHUB_TOKEN }}"
           VERSION=${{ needs.release.outputs.version }}
           cd dist
 


### PR DESCRIPTION
Retires this repo's use of the `MOMENTO_MACHINE_USER_GITHUB_TOKEN` org secret, a
classic PAT on a shared machine user that had to be renewed by hand every 90 days.

- Work that creates a ref, opens a PR, or reaches another repo now mints a
  short-lived installation token from the `momento-release-bot` GitHub App.
  A push or PR authored by the built-in `GITHUB_TOKEN` deliberately does not
  start a workflow run, so release automation needs an app token to keep CI firing.
- Same-repo work now uses the built-in `GITHUB_TOKEN`, with an explicit
  `permissions:` block wherever it writes. No shared credential involved.

`MOMENTO_RELEASE_APP_ID` and `MOMENTO_RELEASE_APP_PRIVATE_KEY` are already
provisioned org-wide, so there is no per-repo setup.
